### PR TITLE
bug fixes to handle context parameter ("con" )

### DIFF
--- a/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDLookUpEPResource.java
+++ b/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDLookUpEPResource.java
@@ -74,7 +74,7 @@ public class RDLookUpEPResource extends CoapResource {
 				
 					result += "<"+node.getContext()+">;"+LinkFormat.END_POINT+"=\""+node.getEndpointIdentifier()+"\"";
 					result += ";"+LinkFormat.DOMAIN+"=\""+node.getDomain()+"\"";
-					if(!node.getEndpointType().isEmpty()){
+					if(node.getEndpointType() != null && !node.getEndpointType().isEmpty()){ // fixed NullPointerException. was: if(!node.getEndpointType().isEmpty()){
 						result += ";"+LinkFormat.RESOURCE_TYPE+"=\""+node.getEndpointType()+"\"";
 					}
 							

--- a/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDNodeResource.java
+++ b/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDNodeResource.java
@@ -88,7 +88,12 @@ public class RDNodeResource extends CoapResource {
 			}
 			
 			if (attr.getName().equals(LinkFormat.CONTEXT)){
-				newContext = attr.getValue();
+				//newContext = attr.getValue();
+				// quick fix of above parsing error:
+				String[] conKeyValueParam = q.split("=");
+				if (conKeyValueParam.length > 0) {
+					newContext = q.split("=")[1];
+				}
 			}
 		}
 
@@ -103,7 +108,8 @@ public class RDNodeResource extends CoapResource {
 				check = new URI("coap", "", request.getSource().getHostAddress(), request.getSourcePort(), "", "", ""); // required to set port
 				context = check.toString().replace("@", "").replace("?", "").replace("#", ""); // URI is a silly class
 			} else {
-				check = new URI(context);
+				check = new URI(newContext); 
+				context = newContext;
 			}
 		} catch (Exception e) {
 			LOGGER.warning(e.toString());


### PR DESCRIPTION
The RD's mechanism to accept the "con" parameter was broken. This update fixes the bug by including a "null" check (in RDLookUpEPResource.java) and preventing to use LinkAttribute to parse the value of the con parameter (in RDNodeResource).
