### PR TITLE
update ep parameters even with RD registeration interface.

### DIFF
--- a/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDResource.java
+++ b/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDResource.java
@@ -79,23 +79,23 @@ public class RDResource extends CoapResource {
 			}
 		}
 		
-		if (resource==null) {
-			
-			// uncomment to use random resource names instead of registered Endpoint Name
-			/*
-			String randomName;
-			do {
-				randomName = Integer.toString((int) (Math.random() * 10000));
-			} while (getChild(randomName) != null);
-			*/
-			
-			resource = new RDNodeResource(endpointName, domain);
-			add(resource);
-			
-			responseCode = ResponseCode.CREATED;
-		} else {
-			responseCode = ResponseCode.CHANGED;
+		//Endpoint unaware of its previous entry in RD: deleting it to put the latest entry. 
+		if (resource!=null) {
+			resource.delete();
 		}
+		
+		// uncomment to use random resource names instead of registered Endpoint Name
+		/*
+		String randomName;
+		do {
+			randomName = Integer.toString((int) (Math.random() * 10000));
+		} while (getChild(randomName) != null);
+		*/
+			
+		resource = new RDNodeResource(endpointName, domain);
+		add(resource);
+			
+		responseCode = ResponseCode.CREATED;
 		
 		// set parameters of resource or abort on failure
 		if (!resource.setParameters(exchange.advanced().getRequest())) {


### PR DESCRIPTION
According RFCs an end point must be able to update its parameters and lifetime value with registration interface as well.

since the 'handlepost' is called to update paramenters when the interface returned by RD is used by the ep, in the solution I have called the same function to process the request and update.

reference :
https://tools.ietf.org/html/draft-ietf-core-resource-directory-04#section-5.3
