### PR TITLE
Update GUIController.java

### DIFF
--- a/cf-browser/src/main/java/org/eclipse/californium/tools/GUIController.java
+++ b/cf-browser/src/main/java/org/eclipse/californium/tools/GUIController.java
@@ -167,11 +167,19 @@ public class GUIController {
     @FXML
     private void onSelectResource() {
         TreeItem<String> item = (TreeItem<String>) resourceTree.getSelectionModel().getSelectedItem();
+		if (item == null) { // Handle case when no node in the tree is selected, just browsed into.
+			return;
+		}
+        
         StringBuilder path = new StringBuilder(item.getValue());
         while(item.getParent() != null) {
             item = item.getParent();
-            path.insert(0, item.getValue());
+            path.insert(0, item.getValue()+"/"); // Add slash seperator to hierarchical paths.
         }
+        // Strip the extra leading slash added in the loop.
+        if (path.toString().startsWith("/")) {
+		path.delete(0,1); 
+	}
         // Prepend the coap uri
         path.insert(0, COAP_PROTOCOL+coapHost);
         log.info("selected resource: "+path);


### PR DESCRIPTION
For the CoAP server I am connecting to, it returns a hierarchy. And this tool was not including the slashes between path elements, and returning extra errors while browsing the tree. This patch corrects both errors.