### PR TITLE
Fix wrong resource type for lookup resources

### DIFF
--- a/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDLookUpEPResource.java
+++ b/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDLookUpEPResource.java
@@ -33,15 +33,15 @@ import org.eclipse.californium.core.server.resources.Resource;
 public class RDLookUpEPResource extends CoapResource {
 
 	private RDResource rdResource = null;
-	
+
 	public RDLookUpEPResource(String resourceIdentifier, RDResource rd) {
 		super(resourceIdentifier);
 		this.rdResource = rd;
-		getAttributes().addResourceType("core.rd-lookup-res");
+		getAttributes().addResourceType("core.rd-lookup-ep");
 		getAttributes().addContentType(MediaTypeRegistry.APPLICATION_LINK_FORMAT);
 	}
 
-	
+
 	@Override
 	public void handleGET(CoapExchange exchange) {
 		Collection<Resource> resources = rdResource.getChildren();

--- a/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDLookUpResResource.java
+++ b/cf-rd/src/main/java/org/eclipse/californium/tools/resources/RDLookUpResResource.java
@@ -31,15 +31,15 @@ import org.eclipse.californium.core.server.resources.Resource;
 public class RDLookUpResResource extends CoapResource {
 
 	private RDResource rdResource = null;
-	
+
 	public RDLookUpResResource(String resourceIdentifier, RDResource rd) {
 		super(resourceIdentifier);
 		this.rdResource = rd;
-		getAttributes().addResourceType("core.rd-lookup-ep");
+		getAttributes().addResourceType("core.rd-lookup-res");
 		getAttributes().addContentType(MediaTypeRegistry.APPLICATION_LINK_FORMAT);
 	}
 
-	
+
 	@Override
 	public void handleGET(CoapExchange exchange) {
 		Collection<Resource> resources = rdResource.getChildren();


### PR DESCRIPTION
This fixes the wrong resource type that are set on the lookup resources in cf-rd.

Signed-off-by: pokgak <m.aimanismail@gmail.com>