### PR TITLE
pump javafx-fxml version

### DIFF
--- a/cf-browser/pom.xml
+++ b/cf-browser/pom.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -116,7 +114,7 @@
 				<dependency>
 					<groupId>org.openjfx</groupId>
 					<artifactId>javafx-fxml</artifactId>
-					<version>11.0.2</version>
+					<version>14</version>
 				</dependency>
 			</dependencies>
 			<build>


### PR DESCRIPTION
Closes #47 

The issue was reported as a [bug](https://bugs.openjdk.java.net/browse/JDK-8234916) in OpenFX and apparently pumping the version to 14 solved the issue and the text is now displaying correctly.
![Screen Shot 2020-09-02 at 12 20 04 PM](https://user-images.githubusercontent.com/6633545/91969585-a31ef580-ed16-11ea-9f19-f945d9a67151.png)
